### PR TITLE
Moar (ok some) tests

### DIFF
--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -36,3 +36,7 @@ jobs:
         run: cargo test
       - name: "Build in release mode"
         run: cargo build --release
+      - name: "Run CLI in debug and release mode" # tests clap, mainly
+        run: |
+          cargo run --release -- --help
+          cargo run -- --help

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,67 @@
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use concread::arcache::ARCache;
+use hashbrown::HashSet;
+use ldap3_proto::{LdapFilter, LdapSearchScope};
+use openssl::ssl::SslConnector;
+use serde::Deserialize;
+use url::Url;
+
+pub mod proxy;
+
+use crate::proxy::{CachedValue, SearchCacheKey};
+
+const MEGABYTES: usize = 1048576;
+
+pub struct AppState {
+    pub tls_params: SslConnector,
+    pub addrs: Vec<SocketAddr>,
+    // Cache later here.
+    pub binddn_map: BTreeMap<String, DnConfig>,
+    pub cache: ARCache<SearchCacheKey, CachedValue>,
+    pub cache_entry_timeout: Duration,
+    pub max_incoming_ber_size: Option<usize>,
+    pub max_proxy_ber_size: Option<usize>,
+    pub allow_all_bind_dns: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct DnConfig {
+    #[serde(default)]
+    pub allowed_queries: HashSet<(String, LdapSearchScope, LdapFilter)>,
+}
+
+fn default_cache_bytes() -> usize {
+    128 * MEGABYTES
+}
+
+fn default_cache_entry_timeout() -> u64 {
+    1800
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub bind: SocketAddr,
+    pub tls_key: PathBuf,
+    pub tls_chain: PathBuf,
+
+    #[serde(default = "default_cache_bytes")]
+    pub cache_bytes: usize,
+    #[serde(default = "default_cache_entry_timeout")]
+    pub cache_entry_timeout: u64,
+
+    pub ldap_ca: PathBuf,
+    pub ldap_url: Url,
+
+    pub max_incoming_ber_size: Option<usize>,
+    pub max_proxy_ber_size: Option<usize>,
+
+    #[serde(default)]
+    pub allow_all_bind_dns: bool,
+
+    #[serde(flatten)]
+    pub binddn_map: BTreeMap<String, DnConfig>,
+}

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -35,14 +35,14 @@ pub struct SearchCacheKey {
 
 #[derive(Debug, Clone)]
 pub struct CachedValue {
-    valid_until: Instant,
-    entries: Vec<(LdapSearchResultEntry, Vec<LdapControl>)>,
-    result: LdapResult,
-    ctrl: Vec<LdapControl>,
+    pub valid_until: Instant,
+    pub entries: Vec<(LdapSearchResultEntry, Vec<LdapControl>)>,
+    pub result: LdapResult,
+    pub ctrl: Vec<LdapControl>,
 }
 
 impl CachedValue {
-    fn size(&self) -> usize {
+    pub fn size(&self) -> usize {
         std::mem::size_of::<Self>() + self.entries.iter().map(|(e, _)| e.size()).sum::<usize>()
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -72,7 +72,7 @@ fn bind_operror(msgid: i32, msg: &str) -> LdapMsg {
     }
 }
 
-pub(crate) async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
+pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
     mut r: FramedRead<R, LdapCodec>,
     mut w: FramedWrite<W, LdapCodec>,
     client_address: SocketAddr,
@@ -423,14 +423,14 @@ pub(crate) async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
 }
 
 #[derive(Debug, Clone)]
-enum LdapError {
+pub enum LdapError {
     TlsError,
     ConnectError,
     Transport,
     InvalidProtocolState,
 }
 
-struct BasicLdapClient {
+pub struct BasicLdapClient {
     r: FramedRead<CR, LdapCodec>,
     w: FramedWrite<CW, LdapCodec>,
     msg_counter: i32,

--- a/tests/test_config.toml
+++ b/tests/test_config.toml
@@ -1,0 +1,26 @@
+
+bind = "127.0.0.1:3636"
+tls_chain = "/etc/ldap-proxy/chain.pem"
+tls_key = "/etc/ldap-proxy/key.pem"
+
+ldap_ca = "/etc/ldap-proxy/ldap-ca.pem"
+ldap_url = "ldaps://ldap.example.com"
+
+[""]
+allowed_queries = [["", "base", "(objectclass=*)"]]
+
+["cn=John Cena,dc=dooo,dc=do,dc=do,dc=doooooo"]
+allowed_queries = [
+    [
+        "",
+        "base",
+        "(objectclass=*)",
+    ],
+    [
+        "o=kanidm",
+        "subtree",
+        "(objectclass=*)",
+    ],
+]
+
+["cn=Administrator"]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,9 @@
 // use ldap_proxy::proxy::BasicLdapClient;
 
+use ldap3_proto::proto::LdapResult;
+use ldap_proxy::proxy::CachedValue;
 use ldap_proxy::Config;
+use std::time::{Duration, Instant};
 
 #[test]
 fn hello_world() {
@@ -15,4 +18,20 @@ fn test_config_load() {
     let config = toml::from_str::<Config>(include_str!("test_config.toml")).unwrap();
 
     assert_eq!(config.ldap_ca.to_str(), Some("/etc/ldap-proxy/ldap-ca.pem"));
+}
+
+#[test]
+fn test_cachedvalue() {
+    let cv = CachedValue {
+        valid_until: Instant::now() + Duration::from_secs(60),
+        entries: Vec::with_capacity(5),
+        result: LdapResult {
+            code: ldap3_proto::LdapResultCode::Busy,
+            matcheddn: "dn=doo".to_string(),
+            message: "ohno".to_string(),
+            referral: Vec::with_capacity(5),
+        },
+        ctrl: Vec::with_capacity(5),
+    };
+    assert_eq!(cv.size(), 144);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,18 @@
+// use ldap_proxy::proxy::BasicLdapClient;
+
+use ldap_proxy::Config;
+
+#[test]
+fn hello_world() {
+    assert_eq!(2 + 2, 4);
+}
+
+#[test]
+fn test_config_load() {
+    assert!(toml::from_str::<Config>("").is_err());
+
+    assert!(toml::from_str::<Config>(include_str!("test_config.toml")).is_ok());
+    let config = toml::from_str::<Config>(include_str!("test_config.toml")).unwrap();
+
+    assert_eq!(config.ldap_ca.to_str(), Some("/etc/ldap-proxy/ldap-ca.pem"));
+}


### PR DESCRIPTION
Mainly so dependabot has a chance of flagging things when an import's wrong. I broke out some internals from `main.rs` into a lib so I can import them, and added runs in CI to check that `clap` is happy (because it panics when things are wrong at runtime, but not at compile time)

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
