### PR TITLE
20260408 allow dn rebinding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "ldap-proxy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "concread",
@@ -680,7 +680,6 @@ dependencies = [
  "haproxy-protocol",
  "hashbrown 0.16.1",
  "ldap3_proto",
- "mimalloc",
  "rustls",
  "serde",
  "serde_with",
@@ -719,16 +718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,15 +743,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "mimalloc"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
-dependencies = [
- "libmimalloc-sys",
-]
 
 [[package]]
 name = "minimal-lexical"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ futures-util = { version = "^0.3.32", features = ["sink"] }
 haproxy-protocol = { version = "0.0.4", features = ["tokio"] }
 hashbrown = { version = "0.16", features = ["serde"] }
 ldap3_proto = { version = "0.7.0", features = ["serde"] }
-mimalloc = "0.1.48"
 rustls = "0.23.37"
 serde = { version = "^1.0.228", features = ["derive"] }
 serde_with = { version = "3.18.0", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ldap-proxy"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ allowed_queries = [
     ["o=example", "subtree", "(objectclass=*)"],
 ]
 
+# In some cases you may want to map anonymous to an authenticated dn. This allows
+# setting the dn and credential that will be used in the mapping.
+#
+# map_to_dn: "uid=remote_user"
+# map_to_secret: "12345"
+
 ["cn=Administrator"]
 # If you don't specify allowed queries, all queries are granted
 
@@ -60,25 +66,6 @@ allowed_queries = [
 
 ## Where do I get it?
 
-* OpenSUSE: `zypper in ldap-proxy`
 * docker: `docker pull firstyear/ldap-proxy:latest`
-
-## FAQ
-
-### Why can't ldap-proxy running under systemd read my certificates?
-
-Because we use systemd dynamic users. This means that ldap-proxy is always isolated in a sandboxed
-user, and that user can dynamically change it's uid/gid.
-
-To resolve this, you need to add ldap-proxy to have a supplemental group that can read your certs.
-
-```
-# systemctl edit ldap-proxy
-[Service]
-SupplementaryGroups=certbot
-```
-
-Then restart ldap-proxy. Also be sure to check that the group has proper execute bits along the
-directory paths and that the certs are readable to the group!
-
+* podman: `podman pull docker.io/firstyear/ldap-proxy:latest`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ pub struct AppState {
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct DnConfig {
+    pub map_to_dn: Option<String>,
+    pub map_to_secret: Option<String>,
     #[serde(default)]
     pub allowed_queries: HashSet<(String, LdapSearchScope, LdapFilterWrapper)>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,6 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use clap::Parser;
 use concread::arcache::ARCacheBuilder;
 use ldap3_proto::LdapCodec;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -44,10 +44,14 @@ impl CachedValue {
     }
 }
 
+// We allow the large enum to exist as we always do a mem swap from unbound to authenticated, so
+// the memory layout penalty doesn't apply.
+#[allow(clippy::large_enum_variant)]
 enum ClientState {
     Unbound,
     Authenticated {
         dn: String,
+        display_dn: String,
         config: DnConfig,
         client: BasicLdapClient,
     },
@@ -93,7 +97,7 @@ pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
                 _,
                 LdapMsg {
                     msgid,
-                    op: LdapOp::BindRequest(lbr),
+                    op: LdapOp::BindRequest(mut lbr),
                     ctrl,
                 },
             ) => {
@@ -128,6 +132,29 @@ pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
                 // need to configure.
 
                 let dn = lbr.dn.clone();
+                if let Some(map_to_dn) = config.map_to_dn.clone() {
+                    // The dn from the client is internally remapped by the proxy. This
+                    // means we need to modify the bind request to update the dn and
+                    // the credential used.
+
+                    lbr.dn = map_to_dn.clone();
+
+                    if let Some(map_to_secret) = config.map_to_secret.clone() {
+                        lbr.cred = LdapBindCred::Simple(map_to_secret);
+                    }
+                };
+
+                let display_dn = if dn.is_empty() {
+                    "anonymous"
+                } else {
+                    dn.as_str()
+                };
+
+                let display_dn = if let Some(map_to_dn) = config.map_to_dn.as_ref() {
+                    format!("{} (mapped to {})", display_dn, map_to_dn)
+                } else {
+                    display_dn.to_string()
+                };
 
                 // We need the client to connect *and* bind to proceed here!
                 let mut client = match BasicLdapClient::build(
@@ -178,8 +205,13 @@ pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
                 };
 
                 if valid {
-                    info!("Successful bind for {}", dn);
-                    Some(ClientState::Authenticated { dn, config, client })
+                    info!("Successful bind for {}", display_dn);
+                    Some(ClientState::Authenticated {
+                        dn,
+                        display_dn,
+                        config,
+                        client,
+                    })
                 } else {
                     None
                 }
@@ -202,6 +234,7 @@ pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
             (
                 ClientState::Authenticated {
                     dn,
+                    display_dn: _,
                     config,
                     ref mut client,
                 },
@@ -368,7 +401,8 @@ pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
             // Extended Requests - Generally has whoami.
             (
                 ClientState::Authenticated {
-                    dn,
+                    dn: _,
+                    display_dn,
                     config: _,
                     client: _,
                 },
@@ -387,7 +421,7 @@ pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
                             referral: vec![],
                         },
                         name: None,
-                        value: Some(Vec::from(dn.as_str())),
+                        value: Some(Vec::from(display_dn.as_str())),
                     }),
                     _ => LdapOp::ExtendedResponse(LdapExtendedResponse {
                         res: LdapResult {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -18,7 +18,7 @@ use tokio::net::TcpStream;
 use tokio::time::timeout;
 use tokio_rustls::{client::TlsStream, TlsConnector};
 use tokio_util::codec::{FramedRead, FramedWrite};
-use tracing::{debug, error, info, span, trace, warn, Level};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 type CR = ReadHalf<TlsStream<TcpStream>>;
 type CW = WriteHalf<TlsStream<TcpStream>>;
@@ -73,6 +73,360 @@ fn bind_operror(msgid: i32, msg: &str) -> LdapMsg {
     }
 }
 
+#[instrument(level = "info", skip_all)]
+async fn bind<W: AsyncWrite + Unpin>(
+    w: &mut FramedWrite<W, LdapCodec>,
+    app_state: &AppState,
+    mut lbr: LdapBindRequest,
+    msgid: i32,
+    ctrl: Vec<LdapControl>,
+) -> Result<Option<ClientState>, LdapError> {
+    trace!(?lbr);
+    // Is the requested bind dn valid per our map?
+    let config = match app_state.binddn_map.get(&lbr.dn) {
+        Some(dnconfig) => {
+            // They have a config! They can proceed.
+            dnconfig.clone()
+        }
+        None => {
+            if app_state.allow_all_bind_dns {
+                // All bind dns are allow, return a default config.
+                DnConfig::default()
+            } else {
+                // Bind dns are filtered, sad trombone time.
+                let resp_msg = bind_operror(msgid, "unable to bind");
+                w.send(resp_msg).await.map_err(|err| {
+                    error!(?err, "Unable to send response");
+                    LdapError::Transport
+                })?;
+                return Ok(None);
+            }
+        }
+    };
+
+    // Okay, we have a dnconfig, so they are allowed to proceed. Lets
+    // now setup the client for their session, and anything else we
+    // need to configure.
+
+    let dn = lbr.dn.clone();
+    if let Some(map_to_dn) = config.map_to_dn.clone() {
+        // The dn from the client is internally remapped by the proxy. This
+        // means we need to modify the bind request to update the dn and
+        // the credential used.
+
+        lbr.dn = map_to_dn.clone();
+
+        if let Some(map_to_secret) = config.map_to_secret.clone() {
+            lbr.cred = LdapBindCred::Simple(map_to_secret);
+        }
+    };
+
+    let display_dn = if dn.is_empty() {
+        "anonymous"
+    } else {
+        dn.as_str()
+    };
+
+    let display_dn = if let Some(map_to_dn) = config.map_to_dn.as_ref() {
+        format!("{} (mapped to {})", display_dn, map_to_dn)
+    } else {
+        display_dn.to_string()
+    };
+
+    // We need the client to connect *and* bind to proceed here!
+    let mut client = match BasicLdapClient::build(
+        &app_state.addrs,
+        &app_state.tls_hostname,
+        &app_state.tls_connector,
+        app_state.max_proxy_ber_size,
+    )
+    .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            error!(?e, "A client build error has occurred.");
+            let resp_msg = bind_operror(msgid, "unable to bind");
+            w.send(resp_msg).await.map_err(|err| {
+                error!(?err, "Unable to send response");
+                LdapError::Transport
+            })?;
+            // Always bail.
+            return Ok(None);
+        }
+    };
+
+    let valid = match client.bind(lbr, ctrl).await {
+        Ok((bind_resp, ctrl)) => {
+            // Almost there, lets check the bind result.
+            let valid = bind_resp.res.code == LdapResultCode::Success;
+
+            let resp_msg = LdapMsg {
+                msgid,
+                op: LdapOp::BindResponse(bind_resp),
+                ctrl,
+            };
+            w.send(resp_msg).await.map_err(|err| {
+                error!(?err, "Unable to send response");
+                LdapError::Transport
+            })?;
+            valid
+        }
+        Err(e) => {
+            error!(?e, "A client bind error has occurred");
+            let resp_msg = bind_operror(msgid, "unable to bind");
+            w.send(resp_msg).await.map_err(|err| {
+                error!(?err, "Unable to send response");
+                LdapError::Transport
+            })?;
+            // Always bail.
+            return Ok(None);
+        }
+    };
+
+    if valid {
+        info!("Successful bind for {}", display_dn);
+        Ok(Some(ClientState::Authenticated {
+            dn,
+            display_dn,
+            config,
+            client,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+#[instrument(level = "info", skip_all)]
+async fn unbind() {}
+
+struct SearchRequest<'a> {
+    sr: LdapSearchRequest,
+    msgid: i32,
+    ctrl: Vec<LdapControl>,
+
+    dn: &'a str,
+    display_dn: &'a str,
+    config: &'a DnConfig,
+    client: &'a mut BasicLdapClient,
+}
+
+#[instrument(level = "info", skip_all)]
+async fn search<W: AsyncWrite + Unpin>(
+    w: &mut FramedWrite<W, LdapCodec>,
+    app_state: &AppState,
+    search_request: SearchRequest<'_>,
+) -> Result<Option<ClientState>, LdapError> {
+    let SearchRequest {
+        sr,
+        msgid,
+        ctrl,
+        dn,
+        display_dn,
+        config,
+        client,
+    } = search_request;
+
+    // Pre check if the search is allowed for this dn / scope / filter
+    if config.allowed_queries.is_empty() {
+        // All queries are allowed.
+        debug!("All queries are allowed");
+    } else {
+        // Let's check the query details.
+        let allow_key = (
+            sr.base.clone(),
+            sr.scope.clone(),
+            LdapFilterWrapper {
+                inner: sr.filter.clone(),
+            },
+        );
+
+        if config.allowed_queries.contains(&allow_key) {
+            // Good to proceed.
+            debug!("Query is granted");
+        } else {
+            warn!(
+                ?allow_key,
+                "Requested query is not allowed for {}", display_dn
+            );
+            // If not, send an empty result.
+            w.send(LdapMsg {
+                msgid,
+                op: LdapOp::SearchResultDone(LdapResult {
+                    code: LdapResultCode::Success,
+                    matcheddn: "".to_string(),
+                    message: "".to_string(),
+                    referral: vec![],
+                }),
+                ctrl,
+            })
+            .await
+            .map_err(|err| {
+                error!(?err, "Unable to send response");
+                LdapError::Transport
+            })?;
+
+            return Ok(None);
+        }
+    };
+
+    // This is done like this to facilitate a cache mechanism in future.
+    //
+    // Cache will need to key on:
+    //    bind_dn
+    //    base
+    //    scope
+    //    deref aliases
+    //    types only
+    //    filter
+    //    attrs
+    //   search controls
+    //
+    // Which is a lot, but it's everything that controls to results to
+    // ensure we don't introduce corruption.
+
+    let now = Instant::now();
+
+    // get the read txn.
+    let mut cache_read_txn = app_state.cache.read();
+
+    let cache_key = SearchCacheKey {
+        bind_dn: dn.to_string(),
+        search: sr.clone(),
+        ctrl: ctrl.clone(),
+    };
+    debug!(?cache_key);
+
+    let maybe_results = cache_read_txn.get(&cache_key).and_then(|cache_value| {
+        if cache_value.valid_until > now {
+            Some(cache_value.clone())
+        } else {
+            debug!("Cache item expired");
+            None
+        }
+    });
+
+    let was_cache_miss = maybe_results.is_none();
+
+    debug!("cache hit {}", !was_cache_miss);
+
+    let (entries, result, ctrl) = match maybe_results {
+        Some(CachedValue {
+            valid_until: _,
+            entries,
+            result,
+            ctrl,
+        }) => (entries, result, ctrl),
+        None => {
+            match client.search(sr, ctrl).await {
+                Ok(data) => data,
+                Err(e) => {
+                    error!(?e, "A client search error has occurred");
+                    let resp_msg = bind_operror(msgid, "unable to search");
+                    w.send(resp_msg).await.map_err(|err| {
+                        error!(?err, "Unable to send response");
+                        LdapError::Transport
+                    })?;
+
+                    // Error sent, return with no state change.
+                    return Ok(None);
+                }
+            }
+        }
+    };
+
+    // Update cache if needed.
+    if was_cache_miss {
+        let cache_value = CachedValue {
+            valid_until: now + app_state.cache_entry_timeout,
+            entries: entries.clone(),
+            result: result.clone(),
+            ctrl: ctrl.clone(),
+        };
+        if let Some(cache_value_size) = NonZeroUsize::new(cache_value.size()) {
+            debug!("Adding entry of size {} to cache", cache_value_size);
+            cache_read_txn.insert_sized(cache_key, cache_value, cache_value_size);
+        } else {
+            error!("Invalid entry size, unable to add to cache");
+        }
+    }
+
+    for (entry, ctrl) in entries {
+        w.send(LdapMsg {
+            msgid,
+            op: LdapOp::SearchResultEntry(entry),
+            ctrl,
+        })
+        .await
+        .map_err(|err| {
+            error!(?err, "Unable to send response");
+            LdapError::Transport
+        })?;
+    }
+
+    w.send(LdapMsg {
+        msgid,
+        op: LdapOp::SearchResultDone(result),
+        ctrl,
+    })
+    .await
+    .map_err(|err| {
+        error!(?err, "Unable to send response");
+        LdapError::Transport
+    })?;
+
+    // Try and quiesce now.
+    app_state.cache.try_quiesce();
+
+    // No state change
+    Ok(None)
+}
+
+#[instrument(level = "info", skip_all)]
+async fn extop<W: AsyncWrite + Unpin>(
+    w: &mut FramedWrite<W, LdapCodec>,
+
+    ler: LdapExtendedRequest,
+    msgid: i32,
+
+    display_dn: &str,
+) -> Result<Option<ClientState>, LdapError> {
+    let op = match ler.name.as_str() {
+        "1.3.6.1.4.1.4203.1.11.3" => LdapOp::ExtendedResponse(LdapExtendedResponse {
+            res: LdapResult {
+                code: LdapResultCode::Success,
+                matcheddn: "".to_string(),
+                message: "".to_string(),
+                referral: vec![],
+            },
+            name: None,
+            value: Some(Vec::from(display_dn)),
+        }),
+        _ => LdapOp::ExtendedResponse(LdapExtendedResponse {
+            res: LdapResult {
+                code: LdapResultCode::OperationsError,
+                matcheddn: "".to_string(),
+                message: "".to_string(),
+                referral: vec![],
+            },
+            name: None,
+            value: None,
+        }),
+    };
+
+    w.send(LdapMsg {
+        msgid,
+        op,
+        ctrl: vec![],
+    })
+    .await
+    .map_err(|err| {
+        error!(?err, "Unable to send response");
+        LdapError::Transport
+    })?;
+
+    Ok(None)
+}
+
 pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
     mut r: FramedRead<R, LdapCodec>,
     mut w: FramedWrite<W, LdapCodec>,
@@ -97,125 +451,13 @@ pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
                 _,
                 LdapMsg {
                     msgid,
-                    op: LdapOp::BindRequest(mut lbr),
+                    op: LdapOp::BindRequest(lbr),
                     ctrl,
                 },
-            ) => {
-                let span = span!(Level::INFO, "bind");
-                let _enter = span.enter();
-
-                trace!(?lbr);
-                // Is the requested bind dn valid per our map?
-                let config = match app_state.binddn_map.get(&lbr.dn) {
-                    Some(dnconfig) => {
-                        // They have a config! They can proceed.
-                        dnconfig.clone()
-                    }
-                    None => {
-                        if app_state.allow_all_bind_dns {
-                            // All bind dns are allow, return a default config.
-                            DnConfig::default()
-                        } else {
-                            // Bind dns are filtered, sad trombone time.
-                            let resp_msg = bind_operror(msgid, "unable to bind");
-                            if w.send(resp_msg).await.is_err() {
-                                error!("Unable to send response");
-                                break;
-                            }
-                            continue;
-                        }
-                    }
-                };
-
-                // Okay, we have a dnconfig, so they are allowed to proceed. Lets
-                // now setup the client for their session, and anything else we
-                // need to configure.
-
-                let dn = lbr.dn.clone();
-                if let Some(map_to_dn) = config.map_to_dn.clone() {
-                    // The dn from the client is internally remapped by the proxy. This
-                    // means we need to modify the bind request to update the dn and
-                    // the credential used.
-
-                    lbr.dn = map_to_dn.clone();
-
-                    if let Some(map_to_secret) = config.map_to_secret.clone() {
-                        lbr.cred = LdapBindCred::Simple(map_to_secret);
-                    }
-                };
-
-                let display_dn = if dn.is_empty() {
-                    "anonymous"
-                } else {
-                    dn.as_str()
-                };
-
-                let display_dn = if let Some(map_to_dn) = config.map_to_dn.as_ref() {
-                    format!("{} (mapped to {})", display_dn, map_to_dn)
-                } else {
-                    display_dn.to_string()
-                };
-
-                // We need the client to connect *and* bind to proceed here!
-                let mut client = match BasicLdapClient::build(
-                    &app_state.addrs,
-                    &app_state.tls_hostname,
-                    &app_state.tls_connector,
-                    app_state.max_proxy_ber_size,
-                )
-                .await
-                {
-                    Ok(c) => c,
-                    Err(e) => {
-                        error!(?e, "A client build error has occurred.");
-                        let resp_msg = bind_operror(msgid, "unable to bind");
-                        if w.send(resp_msg).await.is_err() {
-                            error!("Unable to send response");
-                        }
-                        // Always bail.
-                        break;
-                    }
-                };
-
-                let valid = match client.bind(lbr, ctrl).await {
-                    Ok((bind_resp, ctrl)) => {
-                        // Almost there, lets check the bind result.
-                        let valid = bind_resp.res.code == LdapResultCode::Success;
-
-                        let resp_msg = LdapMsg {
-                            msgid,
-                            op: LdapOp::BindResponse(bind_resp),
-                            ctrl,
-                        };
-                        if w.send(resp_msg).await.is_err() {
-                            error!("Unable to send response");
-                            break;
-                        }
-                        valid
-                    }
-                    Err(e) => {
-                        error!(?e, "A client bind error has occurred");
-                        let resp_msg = bind_operror(msgid, "unable to bind");
-                        if w.send(resp_msg).await.is_err() {
-                            error!("Unable to send response");
-                        }
-                        // Always bail.
-                        break;
-                    }
-                };
-
-                if valid {
-                    info!("Successful bind for {}", display_dn);
-                    Some(ClientState::Authenticated {
-                        dn,
-                        display_dn,
-                        config,
-                        client,
-                    })
-                } else {
-                    None
-                }
-            }
+            ) => match bind(&mut w, &app_state, lbr, msgid, ctrl).await {
+                Ok(ns) => ns,
+                Err(_) => break,
+            },
             // Unbinds are always actioned.
             (
                 _,
@@ -225,7 +467,7 @@ pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
                     ctrl: _,
                 },
             ) => {
-                trace!("unbind");
+                unbind().await;
                 break;
             }
 
@@ -234,7 +476,7 @@ pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
             (
                 ClientState::Authenticated {
                     dn,
-                    display_dn: _,
+                    display_dn,
                     config,
                     ref mut client,
                 },
@@ -244,161 +486,22 @@ pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
                     ctrl,
                 },
             ) => {
-                let span = span!(Level::INFO, "search");
-                let _enter = span.enter();
-
-                // Pre check if the search is allowed for this dn / scope / filter
-                if config.allowed_queries.is_empty() {
-                    // All queries are allowed.
-                    debug!("All queries are allowed");
-                } else {
-                    // Let's check the query details.
-                    let allow_key = (
-                        sr.base.clone(),
-                        sr.scope.clone(),
-                        LdapFilterWrapper {
-                            inner: sr.filter.clone(),
-                        },
-                    );
-
-                    if config.allowed_queries.contains(&allow_key) {
-                        // Good to proceed.
-                        debug!("Query is granted");
-                    } else {
-                        warn!(?allow_key, "Requested query is not allowed for {}", dn);
-                        // If not, send an empty result.
-                        if w.send(LdapMsg {
-                            msgid,
-                            op: LdapOp::SearchResultDone(LdapResult {
-                                code: LdapResultCode::Success,
-                                matcheddn: "".to_string(),
-                                message: "".to_string(),
-                                referral: vec![],
-                            }),
-                            ctrl,
-                        })
-                        .await
-                        .is_err()
-                        {
-                            error!("Unable to send response");
-                        }
-                        // Always bail.
-                        break;
-                    }
-                };
-
-                // This is done like this to facilitate a cache mechanism in future.
-                //
-                // Cache will need to key on:
-                //    bind_dn
-                //    base
-                //    scope
-                //    deref aliases
-                //    types only
-                //    filter
-                //    attrs
-                //   search controls
-                //
-                // Which is a lot, but it's everything that controls to results to
-                // ensure we don't introduce corruption.
-
-                let now = Instant::now();
-
-                // get the read txn.
-                let mut cache_read_txn = app_state.cache.read();
-
-                let cache_key = SearchCacheKey {
-                    bind_dn: dn.clone(),
-                    search: sr.clone(),
-                    ctrl: ctrl.clone(),
-                };
-                debug!(?cache_key);
-
-                let maybe_results = cache_read_txn.get(&cache_key).and_then(|cache_value| {
-                    if cache_value.valid_until > now {
-                        Some(cache_value.clone())
-                    } else {
-                        debug!("Cache item expired");
-                        None
-                    }
-                });
-
-                let was_cache_miss = maybe_results.is_none();
-
-                debug!("cache hit {}", !was_cache_miss);
-
-                let (entries, result, ctrl) = match maybe_results {
-                    Some(CachedValue {
-                        valid_until: _,
-                        entries,
-                        result,
-                        ctrl,
-                    }) => (entries, result, ctrl),
-                    None => {
-                        match client.search(sr, ctrl).await {
-                            Ok(data) => data,
-                            Err(e) => {
-                                error!(?e, "A client search error has occurred");
-                                let resp_msg = bind_operror(msgid, "unable to search");
-                                if w.send(resp_msg).await.is_err() {
-                                    error!("Unable to send response");
-                                }
-                                // Always bail.
-                                break;
-                            }
-                        }
-                    }
-                };
-
-                // Update cache if needed.
-                if was_cache_miss {
-                    let cache_value = CachedValue {
-                        valid_until: now + app_state.cache_entry_timeout,
-                        entries: entries.clone(),
-                        result: result.clone(),
-                        ctrl: ctrl.clone(),
-                    };
-                    if let Some(cache_value_size) = NonZeroUsize::new(cache_value.size()) {
-                        debug!("Adding entry of size {} to cache", cache_value_size);
-                        cache_read_txn.insert_sized(cache_key, cache_value, cache_value_size);
-                    } else {
-                        error!("Invalid entry size, unable to add to cache");
-                    }
-                }
-
-                for (entry, ctrl) in entries {
-                    if w.send(LdapMsg {
-                        msgid,
-                        op: LdapOp::SearchResultEntry(entry),
-                        ctrl,
-                    })
-                    .await
-                    .is_err()
-                    {
-                        error!("Unable to send response");
-                        break;
-                    }
-                }
-
-                if w.send(LdapMsg {
+                let search_req = SearchRequest {
+                    sr,
                     msgid,
-                    op: LdapOp::SearchResultDone(result),
                     ctrl,
-                })
-                .await
-                .is_err()
-                {
-                    error!("Unable to send response");
-                    break;
+                    dn,
+                    display_dn,
+                    config,
+                    client,
+                };
+
+                match search(&mut w, &app_state, search_req).await {
+                    Ok(ns) => ns,
+                    Err(_) => break,
                 }
-
-                // Try and quiesce now.
-                app_state.cache.try_quiesce();
-
-                // No state change
-                None
             }
-            // Extended Requests - Generally has whoami.
+            // Extended Requests - Generally whoami.
             (
                 ClientState::Authenticated {
                     dn: _,
@@ -411,44 +514,10 @@ pub async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
                     op: LdapOp::ExtendedRequest(ler),
                     ctrl: _,
                 },
-            ) => {
-                let op = match ler.name.as_str() {
-                    "1.3.6.1.4.1.4203.1.11.3" => LdapOp::ExtendedResponse(LdapExtendedResponse {
-                        res: LdapResult {
-                            code: LdapResultCode::Success,
-                            matcheddn: "".to_string(),
-                            message: "".to_string(),
-                            referral: vec![],
-                        },
-                        name: None,
-                        value: Some(Vec::from(display_dn.as_str())),
-                    }),
-                    _ => LdapOp::ExtendedResponse(LdapExtendedResponse {
-                        res: LdapResult {
-                            code: LdapResultCode::OperationsError,
-                            matcheddn: "".to_string(),
-                            message: "".to_string(),
-                            referral: vec![],
-                        },
-                        name: None,
-                        value: None,
-                    }),
-                };
-
-                if w.send(LdapMsg {
-                    msgid,
-                    op,
-                    ctrl: vec![],
-                })
-                .await
-                .is_err()
-                {
-                    error!("Unable to send response");
-                    break;
-                }
-
-                None
-            }
+            ) => match extop(&mut w, ler, msgid, display_dn).await {
+                Ok(ns) => ns,
+                Err(_) => break,
+            },
             // Unknown message handler.
             (_, msg) => {
                 debug!(?msg);


### PR DESCRIPTION
This allows re-mapping a dn so that if you query the proxy as anonymous, the proxy will perform the query as though it is the mapped user. 

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
